### PR TITLE
Content-ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Returns `null` or subject as string.
 const sampleBillAttachment = {
   type: 'application/pdf',
   filename: 'sample-bill.pdf',
+  contentId: 'abc123', // optional, can be used in case you need to show an image in email body like: <img src="cid:abc123">
   base64Data: '' /* Base64 encoded value of the file content.
   fs.readFileSync('./sample-bill.pdf').toString('base64') for example. */
 }

--- a/src/index.js
+++ b/src/index.js
@@ -147,6 +147,7 @@ MIMEMessage.prototype.setAttachments = function setAttachments(attachments) {
     const type = objectkit.getProp(attachment, 'type')
     const filename = objectkit.getProp(attachment, 'filename')
     const base64Data = objectkit.getProp(attachment, 'base64Data')
+    const contentId = objectkit.getProp(attachment, 'contentId')
 
     if (!validationkit.isEmpty(type)
       && !validationkit.isEmpty(filename)
@@ -156,6 +157,9 @@ MIMEMessage.prototype.setAttachments = function setAttachments(attachments) {
       lines.push('--' + this.boundaryMixed)
       lines.push('Content-Type: ' + attachment.type)
       lines.push('Content-Transfer-Encoding: base64')
+      if(contentId) {
+        lines.push('Content-Id: <' + contentId + '>')
+      }
       lines.push('Content-Disposition: attachment;filename="' + attachment.filename + '"')
       lines.push('')
       lines.push(attachment.base64Data)


### PR DESCRIPTION
needed for using embedding images in gmail (<img src="cid:abc">)

the issue: https://stackoverflow.com/questions/9110091/base64-encoded-images-in-email-signatures/9110164#9110164