### PR TITLE
Remove special case that breaks 'Reply-To'

### DIFF
--- a/src/MIMEMessageHeader.js
+++ b/src/MIMEMessageHeader.js
@@ -40,13 +40,6 @@ export default class MIMEMessageHeader {
       },
       {
         placement: 'header',
-        name: 'Reply-To',
-        dump: (v) => {
-          return v.dump()
-        }
-      },
-      {
-        placement: 'header',
         name: 'To',
         required: true,
         dump: (vs) => {

--- a/src/MIMEMessageHeader.js
+++ b/src/MIMEMessageHeader.js
@@ -40,6 +40,13 @@ export default class MIMEMessageHeader {
       },
       {
         placement: 'header',
+        name: 'Reply-To',
+        dump: (v) => {
+          return v
+        }
+      },
+      {
+        placement: 'header',
         name: 'To',
         required: true,
         dump: (vs) => {


### PR DESCRIPTION
Currently if one does `msg.setHeader('Reply-To', 'value')` that will save the value to the existing instance of `Reply-To` in the headers' `this.store`, and then at dump time the value will be called with `.dump()`, which breaks because `'value'` will be a string and won't have a `.dump()` method.

If we just remove this special case then the `Reply-To` header will be added normally.