### PR TITLE
fix: correctly text.trim() in parseSpecCompliantText

### DIFF
--- a/src/Mailbox.js
+++ b/src/Mailbox.js
@@ -35,7 +35,7 @@ export default class Mailbox {
   }
 
   parseSpecCompliantText(text) {
-    text.trim()
+    text = text.trim()
 
     if (text.slice(0, 1) == '<' && text.slice(-1) == '>') {
       return {addr: text.slice(1, -1)}

--- a/tests/unit.js
+++ b/tests/unit.js
@@ -18,6 +18,10 @@ assert.strictEqual(msg1.getSender().name, 'Lorem Ipsum')
 assert.strictEqual(msg1.getSender().addr, 'lorem@ipsum.com')
 assert.strictEqual(msg1.getSender().type.toLowerCase(), 'from')
 
+msg1.setSender(' Lorem Ipsum Trimmus <lorem@ipsum.trimmus.com> ')
+assert.strictEqual(msg1.getSender().name, 'Lorem Ipsum Trimmus')
+assert.strictEqual(msg1.getSender().addr, 'lorem@ipsum.trimmus.com')
+
 msg1.setTo({name: 'Foo Bör', addr: 'foobor@test.com'})
 assert.strictEqual(msg1.getRecipients({type: 'to'}).length > 0, true)
 assert.strictEqual(msg1.getRecipients({type: 'to'})[0].name, 'Foo Bör')


### PR DESCRIPTION
Fixes #15.