### PR TITLE
Allow injecting custom envCtx

### DIFF
--- a/src/entrypoints/browser.js
+++ b/src/entrypoints/browser.js
@@ -1,6 +1,6 @@
 import MIMEMessage from '../MIMEMessage.js'
 
-const envctx = {
+const defaultBrowserEnvCtx = {
   toBase64: function toBase64(data) {
     return btoa(data)
   },
@@ -13,11 +13,11 @@ const envctx = {
 }
 
 class NodeMIMEMessage extends MIMEMessage {
-  constructor() {
-    super(envctx)
+  constructor(envctx) {
+    super({...defaultBrowserEnvCtx, ...envctx})
   }
 }
 
-export function createMimeMessage() {
-  return new NodeMIMEMessage()
+export function createMimeMessage(envctx) {
+  return new NodeMIMEMessage(envctx)
 }

--- a/src/entrypoints/gas.js
+++ b/src/entrypoints/gas.js
@@ -1,6 +1,6 @@
 import MIMEMessage from '../MIMEMessage.js'
 
-const envctx = {
+const defaultGasEnvCtx = {
   toBase64: function toBase64(data) {
     return Utilities.base64Encode(data, Utilities.Charset.UTF_8)
   },
@@ -10,11 +10,11 @@ const envctx = {
 }
 
 class GasMIMEMessage extends MIMEMessage {
-  constructor() {
-    super(envctx)
+  constructor(envctx) {
+    super({...defaultGasEnvCtx, ...envctx})
   }
 }
 
-export function createMimeMessage() {
-  return new GasMIMEMessage()
+export function createMimeMessage(envctx) {
+  return new GasMIMEMessage(envctx)
 }

--- a/src/entrypoints/node.js
+++ b/src/entrypoints/node.js
@@ -1,6 +1,6 @@
 import MIMEMessage from '../MIMEMessage.js'
 
-const envctx = {
+const defaultNodeEnvCtx = {
   toBase64: function toBase64(data) {
     return Buffer.from(data).toString('base64')
   },
@@ -13,11 +13,11 @@ const envctx = {
 }
 
 class NodeMIMEMessage extends MIMEMessage {
-  constructor() {
-    super(envctx)
+  constructor(envctx) {
+    super({...defaultNodeEnvCtx, ...envctx})
   }
 }
 
-export function createMimeMessage() {
-  return new NodeMIMEMessage()
+export function createMimeMessage(envctx) {
+  return new NodeMIMEMessage(envctx)
 }


### PR DESCRIPTION
Resolves #19 

No breaking changes, all existing implementations will work the same. They will just have the ability to replace the base64 encoding implementation used by the library. 