### PR TITLE
Allow required fields to be set to empty string

### DIFF
--- a/src/MIMEMessageHeader.js
+++ b/src/MIMEMessageHeader.js
@@ -172,7 +172,7 @@ export default class MIMEMessageHeader {
           ? item.generator(ctx)
           : null
 
-      if (!v && item.required) {
+      if ((typeof v === 'undefined' || typeof v === 'null') && item.required) {
         throw new MIMETextError('MISSING_HEADER', `The "${item.name}" header is required.`)
       }
 


### PR DESCRIPTION
Should be able to send `subject=''`
I'm not sure `subject` should be required either