### PR TITLE
fixed types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -47,7 +47,7 @@ declare module 'mimetext' {
         envctx: EnvironmentContext
         headers: MIMEMessageContentHeader
         data: string
-        new(envctx: EnvironmentContext, data: string, headers = {}): MIMEMessageContent
+        new(envctx: EnvironmentContext, data: string, headers?: ContentHeaders): MIMEMessageContent
         dump(): string
         isAttachment(): boolean
         isInlineAttachment(): boolean
@@ -78,7 +78,7 @@ declare module 'mimetext' {
         setSender(input: MailboxAddrObject | MailboxAddrText | Email, config?: {type: MailboxType}): Mailbox
         getSender(): Mailbox | undefined
         setRecipients(input: MailboxAddrObject | MailboxAddrText | Email | MailboxAddrObject[] | MailboxAddrText[] | Email[], config: {type: MailboxType}): Mailbox[]
-        getRecipients(config: {type: MailboxType} = {type: 'To'}): Mailbox | Mailbox[] | undefined
+        getRecipients(config?: {type: MailboxType}): Mailbox | Mailbox[] | undefined
         setRecipient(input: MailboxAddrObject | MailboxAddrText | Email | MailboxAddrObject[] | MailboxAddrText[] | Email[]): Mailbox[]
         setTo(input: MailboxAddrObject | MailboxAddrText | Email | MailboxAddrObject[] | MailboxAddrText[] | Email[]): Mailbox[]
         setCc(input: MailboxAddrObject | MailboxAddrText | Email | MailboxAddrObject[] | MailboxAddrText[] | Email[]): Mailbox[]
@@ -145,7 +145,7 @@ declare module 'mimetext' {
         'Content-Transfer-Encoding'?: ContentTransferEncoding,
         'Content-Disposition'?: string,
         'Content-ID'?: string,
-        [index: string]: string
+        [index: string]: string | undefined
     }
 
     export type ContentOptions = {


### PR DESCRIPTION
The following errors appeared when running `npm run build`.

This PR should fix the type definitions.

```
node_modules/mimetext/types/index.d.ts:50:55 - error TS2371: A parameter initializer is only allowed in a function or constructor implementation.

50         new(envctx: EnvironmentContext, data: string, headers = {}): MIMEMessageContent
                                                         ~~~~~~~~~~~~

node_modules/mimetext/types/index.d.ts:81:23 - error TS2371: A parameter initializer is only allowed in a function or constructor implementation.

81         getRecipients(config: {type: MailboxType} = {type: 'To'}): Mailbox | Mailbox[] | undefined
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/mimetext/types/index.d.ts:144:9 - error TS2411: Property ''Content-Type'' of type 'string | undefined' is not assignable to 'string' index type 'string'.

144         'Content-Type'?: string,
            ~~~~~~~~~~~~~~

node_modules/mimetext/types/index.d.ts:145:9 - error TS2411: Property ''Content-Transfer-Encoding'' of type 'ContentTransferEncoding | undefined' is not assignable to 'string' index type 'string'.

145         'Content-Transfer-Encoding'?: ContentTransferEncoding,
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/mimetext/types/index.d.ts:146:9 - error TS2411: Property ''Content-Disposition'' of type 'string | undefined' is not assignable to 'string' index type 'string'.

146         'Content-Disposition'?: string,
            ~~~~~~~~~~~~~~~~~~~~~

node_modules/mimetext/types/index.d.ts:147:9 - error TS2411: Property ''Content-ID'' of type 'string | undefined' is not assignable to 'string' index type 'string'.

147         'Content-ID'?: string,
```