### PR TITLE
fix: mailbox addressing parsing for non whitespace delimited mailbox parts

### DIFF
--- a/build/Mailbox.js
+++ b/build/Mailbox.js
@@ -29,7 +29,8 @@ export class Mailbox {
                 this.addr = text.slice(1, -1);
                 return this;
             }
-            const arr = text.split(' <');
+            const arr = text.split('<');
+            arr[0] = arr[0].trim();
             arr[0] = /^("|')/.test(arr[0]) ? arr[0].slice(1) : arr[0];
             arr[0] = /("|')$/.test(arr[0]) ? arr[0].slice(0, -1) : arr[0];
             arr[1] = arr[1].slice(0, -1);

--- a/tests/MIMEMessage.spec.js
+++ b/tests/MIMEMessage.spec.js
@@ -4,7 +4,6 @@ import * as mime from 'mime-types'
 import {MIMEMessage} from '../build/MIMEMessage'
 import {Mailbox} from '../build/Mailbox'
 import {MIMEMessageContent} from '../build/MIMEMessageContent'
-import {MIMETextError} from '../dist/node/mimetext.es.js'
 
 const envctx = {
     toBase64: function toBase64(data) {

--- a/tests/Mailbox.spec.js
+++ b/tests/Mailbox.spec.js
@@ -4,6 +4,8 @@ import {Mailbox} from '../build/Mailbox'
 const input1 = 'test@mail.com'
 const input2 = 'Test Lorem Ipsum <test@mail.com>'
 const input3 = {addr: 'test@mail.com', name: 'Test Lorem Ipsum', type: 'From'}
+const input4 = 'LoremIpsum<test@mail.com>'
+const input5 = '"LoremIpsum" <test@mail.com>'
 
 test('it accepts objects and texts in a certain format.', () => {
     const mail = new Mailbox(input1)
@@ -20,6 +22,16 @@ test('it accepts objects and texts in a certain format.', () => {
     expect(mail3.addr).toBe('test@mail.com')
     expect(mail3.name).toBe('Test Lorem Ipsum')
     expect(mail3.type).toBe('From')
+
+    const mail4 = new Mailbox(input4)
+    expect(mail4.addr).toBe('test@mail.com')
+    expect(mail4.name).toBe('LoremIpsum')
+    expect(mail4.type).toBe('To')
+
+    const mail5 = new Mailbox(input5)
+    expect(mail5.addr).toBe('test@mail.com')
+    expect(mail5.name).toBe('LoremIpsum')
+    expect(mail5.type).toBe('To')
 })
 
 test('gets domain part of the address', () => {


### PR DESCRIPTION
According to the Regex validation inside Mimetext and RFC, a mailbox like `LoremIpsum<test@mail.com>` is valid.

This however caused a an exception before:
```
new Mailbox('LoremIpsum<test@mail.com>')

->
Cannot read properties of undefined (reading 'slice')
TypeError: Cannot read properties of undefined (reading 'slice')
    at Mailbox.parse (/Users/larsfronius/git/MIMEText/build/Mailbox.js:36:29)
    at new Mailbox (/Users/larsfronius/git/MIMEText/build/Mailbox.js:9:14)
```

This is to fix that behaviour.