### PR TITLE
Add types to exports (fixes issue #38 for ES imports)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,21 +6,33 @@
   "exports": {
     ".": {
       "node": {
-        "import": "./dist/node/mimetext.es.js",
+        "import": {
+          "types": "./types/index.d.ts",
+          "default": "./dist/node/mimetext.es.js"
+        },
         "require": "./dist/node/mimetext.cjs",
         "default": "./dist/node/mimetext.cjs"
       },
-      "import": "./dist/browser/mimetext.es.js",
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/browser/mimetext.es.js"
+      },
       "require": "./dist/browser/mimetext.cjs",
       "default": "./dist/browser/mimetext.cjs"
     },
     "./browser": {
-      "import": "./dist/browser/mimetext.es.js",
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/browser/mimetext.es.js"
+      },
       "require": "./dist/browser/mimetext.cjs",
       "default": "./dist/browser/mimetext.cjs"
     },
     "./node": {
-      "import": "./dist/node/mimetext.es.js",
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/node/mimetext.es.js"
+      },
       "require": "./dist/node/mimetext.cjs",
       "default": "./dist/node/mimetext.cjs"
     },


### PR DESCRIPTION
See TypeScript issue here: https://github.com/microsoft/TypeScript/issues/52363 I don't entirely follow what TS is doing, but I've based this commit on a PR linked from that discussion: https://github.com/gxmari007/vite-plugin-eslint/pull/60

I don't think this will work for CJS imports as TS seems to be pedantic around file suffixes -- we may need to copy or wrap the .d.ts file somehow. I'll investigate that separately.