### PR TITLE
Add `types` fields under `exports` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,24 +8,29 @@
       "node": {
         "import": "./dist/node/mimetext.es.js",
         "require": "./dist/node/mimetext.cjs",
-        "default": "./dist/node/mimetext.cjs"
+        "default": "./dist/node/mimetext.cjs",
+        "types": "./types/index.d.ts"
       },
       "import": "./dist/browser/mimetext.es.js",
       "require": "./dist/browser/mimetext.cjs",
-      "default": "./dist/browser/mimetext.cjs"
+      "default": "./dist/browser/mimetext.cjs",
+      "types": "./types/index.d.ts"
     },
     "./browser": {
       "import": "./dist/browser/mimetext.es.js",
       "require": "./dist/browser/mimetext.cjs",
-      "default": "./dist/browser/mimetext.cjs"
+      "default": "./dist/browser/mimetext.cjs",
+      "types": "./types/index.d.ts"
     },
     "./node": {
       "import": "./dist/node/mimetext.es.js",
       "require": "./dist/node/mimetext.cjs",
-      "default": "./dist/node/mimetext.cjs"
+      "default": "./dist/node/mimetext.cjs",
+      "types": "./types/index.d.ts"
     },
     "./gas": {
-      "default": "./dist/gas/mimetext.js"
+      "default": "./dist/gas/mimetext.js",
+      "types": "./types/index.d.ts"
     }
   },
   "main": "dist/node/mimetext.cjs",


### PR DESCRIPTION
Currently, `mimetext` cannot be imported in latest TypeScript versions using ESM because TypeScript will expect a `types` field under `exports` if `exports` is used, meaning it cannot find the types for the module.

See https://arethetypeswrong.github.io/?p=mimetext%403.0.16

This PR adds the `types` fields to each `exports` field, making the package importable in latest TypeScript and ESM settings. The old `types` field is preserved for BC.